### PR TITLE
refactor: remove term-ansicolor gem and update internal packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,6 @@ end
 group :local_development do
   gem "pry-byebug"
 end
+
+gem 'pact-support', git: "https://github.com/joinhandshake/pact-support", ref: '0fa46bdaf27382a9eb86c9dfbcbca44d7b5e742c'
+gem "pact-mock_service", git: "https://github.com/joinhandshake/pact-mock_service", ref: "1696b14465316dff565142714bf5443907208bde"

--- a/lib/pact/provider/help/console_text.rb
+++ b/lib/pact/provider/help/console_text.rb
@@ -2,14 +2,12 @@ require 'pact/provider/help/content'
 require 'fileutils'
 require 'pact/consumer/configuration'
 require 'pact/provider/help/write'
-require 'term/ansicolor'
+require 'rainbow'
 
 module Pact
   module Provider
     module Help
       class ConsoleText
-
-        C = ::Term::ANSIColor
 
         def self.call reports_dir = Pact.configuration.reports_dir, options = {color: true}
           new(reports_dir || Pact.configuration.reports_dir, options).call
@@ -46,12 +44,10 @@ module Pact
         end
 
         def error_text_coloured
-          C.red(error_text_plain)
+          Rainbow(error_text_plain).red
         end
 
         class ColorizeMarkdown
-
-          C = ::Term::ANSIColor
 
           def self.call markdown
             markdown.split("\n").collect do | line |
@@ -66,11 +62,11 @@ module Pact
           end
 
           def self.yellow_underling string
-            C.underline(C.yellow(string))
+            Rainbow(string).yellow.underline
           end
 
           def self.green string
-            C.green(string)
+            Rainbow(string).green
           end
 
         end

--- a/lib/pact/provider/help/prompt_text.rb
+++ b/lib/pact/provider/help/prompt_text.rb
@@ -1,13 +1,11 @@
 require 'pact/consumer/configuration'
-require 'term/ansicolor'
+require 'rainbow'
 require 'pathname'
 
 module Pact
   module Provider
     module Help
       class PromptText
-
-        C = ::Term::ANSIColor
 
         def self.call reports_dir = Pact.configuration.reports_dir, options = {color: Pact.configuration.color_enabled}
           new(reports_dir, options).call
@@ -31,7 +29,7 @@ module Pact
         end
 
         def prompt_text_colored
-          C.yellow(prompt_text_plain)
+          Rainbow(prompt_text_plain).yellow
         end
 
         def rake_args

--- a/lib/pact/provider/matchers/messages.rb
+++ b/lib/pact/provider/matchers/messages.rb
@@ -1,15 +1,13 @@
-require 'term/ansicolor'
+require 'rainbow'
 require 'pact/term'
 
 module Pact
   module Matchers
     module Messages
 
-      C = ::Term::ANSIColor
-
       def match_term_failure_message diff, actual, diff_formatter, color_enabled
         actual_string = String === actual ? actual : actual.to_json
-        maybe_coloured_string = color_enabled ? C.white(actual_string) : actual_string
+        maybe_coloured_string = color_enabled ? Rainbow(actual_string).white : actual_string
         message = "Actual: #{maybe_coloured_string}\n\n"
         formatted_diff = diff_formatter.call(diff)
         message + colorize_if_enabled(formatted_diff, color_enabled)
@@ -38,9 +36,9 @@ module Pact
       def colorize_if_enabled formatted_diff, color_enabled
         if color_enabled
           # RSpec wraps each line in the failure message with failure_color, turning it red.
-          # To ensure the lines in the diff that should be white, stay white, put an
-          # ANSI reset at the start of each line.
-          formatted_diff.split("\n").collect{ |line| ::Term::ANSIColor.reset + line }.join("\n")
+          # To ensure the lines in the diff that should be white, stay white, wrap each line
+          # in ANSI white.
+          formatted_diff.split("\n").collect{ |line| Rainbow(line).white }.join("\n")
         else
           formatted_diff
         end

--- a/lib/pact/provider/print_missing_provider_states.rb
+++ b/lib/pact/provider/print_missing_provider_states.rb
@@ -1,10 +1,8 @@
-require 'term/ansicolor'
+require 'rainbow'
 
 module Pact
   module Provider
     class PrintMissingProviderStates
-
-      C = ::Term::ANSIColor
 
       # Hash of consumer names to array of names of missing provider states
       def self.call missing_provider_states, output
@@ -15,8 +13,8 @@ module Pact
 
       def self.colorize string
         lines = string.split("\n")
-        first_line = C.cyan(C.underline(lines[0]))
-        other_lines = C.cyan(lines[1..-1].join("\n"))
+        first_line = Rainbow(lines[0]).cyan.underline
+        other_lines = Rainbow(lines[1..-1].join("\n")).cyan
         first_line + "\n" + other_lines
       end
 

--- a/lib/pact/provider/rspec/formatter_rspec_2.rb
+++ b/lib/pact/provider/rspec/formatter_rspec_2.rb
@@ -1,6 +1,5 @@
 require 'pact/provider/print_missing_provider_states'
 require 'rspec/core/formatters/documentation_formatter'
-require 'term/ansicolor'
 require 'pact/provider/help/prompt_text'
 
 module Pact
@@ -12,8 +11,6 @@ module Pact
           def dump_commands_to_rerun_failed_examples
           end
         end
-
-        C = ::Term::ANSIColor
 
         def dump_commands_to_rerun_failed_examples
           return if failed_examples.empty?

--- a/lib/pact/provider/rspec/formatter_rspec_3.rb
+++ b/lib/pact/provider/rspec/formatter_rspec_3.rb
@@ -1,6 +1,5 @@
 require 'pact/provider/print_missing_provider_states'
 require 'rspec/core/formatters'
-require 'term/ansicolor'
 require 'pact/provider/help/prompt_text'
 
 module Pact
@@ -21,9 +20,6 @@ module Pact
           ::RSpec::Core::Formatters.register self, :example_group_started, :example_group_finished,
                                     :example_passed, :example_pending, :example_failed
         end
-
-        C = ::Term::ANSIColor
-
         def example_group_started(notification)
           # This is the metadata on the top level "Verifying a pact between X and Y" describe block
           if @group_level == 0

--- a/lib/pact/provider/rspec/pact_broker_formatter.rb
+++ b/lib/pact/provider/rspec/pact_broker_formatter.rb
@@ -1,6 +1,6 @@
 require 'rspec/core/formatters'
 require 'pact/provider/verification_results/publish_all'
-require 'term/ansicolor'
+require 'rainbow'
 require 'pact/matchers/extract_diff_messages'
 
 module Pact
@@ -43,7 +43,7 @@ module Pact
             if example.exception
               hash[:exception] =  {
                 class: example.exception.class.name,
-                message: ::Term::ANSIColor.uncolor(example.exception.message)
+                  message: Rainbow(example.exception.message).white
               }
             end
 

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -15,12 +15,12 @@ namespace :pact do
 
   desc "Verifies the pact at the given URI against this service provider."
   task 'verify:at', :pact_uri do | t, args |
-    require 'term/ansicolor'
+    require 'rainbow'
     require 'pact/tasks/task_helper'
 
     include Pact::TaskHelper
 
-    abort(::Term::ANSIColor.red("Please provide a pact URI. eg. rake pact:verify:at[../my-consumer/spec/pacts/my_consumer-my_provider.json]")) unless args[:pact_uri]
+    abort(Rainbow("Please provide a pact URI. eg. rake pact:verify:at[../my-consumer/spec/pacts/my_consumer-my_provider.json]").red) unless args[:pact_uri]
     handle_verification_failure do
       execute_pact_verify args[:pact_uri]
     end

--- a/pact.gemspec
+++ b/pact.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 2.0.0'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
-  gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
+  gem.add_runtime_dependency "rainbow", "~> 3.0"
 
-  gem.add_runtime_dependency 'pact-support', '~> 1.16', '>= 1.16.9'
-  gem.add_runtime_dependency 'pact-mock_service', '~> 3.0', '>= 3.3.1'
+  gem.add_runtime_dependency 'pact-support', '~> 1.17', '>= 1.16.9'
+  gem.add_runtime_dependency 'pact-mock_service', '~> 3.9', '>= 3.3.1'
 
   gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'webmock', '~> 3.0'

--- a/spec/lib/pact/provider/matchers/messages_spec.rb
+++ b/spec/lib/pact/provider/matchers/messages_spec.rb
@@ -12,12 +12,10 @@ module Pact
         let(:diff_formatter) { Pact::Matchers::UnixDiffFormatter }
         let(:message) { "line1\nline2"}
         let(:output_message) { "Actual: actual\n\n#{message}"}
-        let(:output_message_with_resets) { "Actual: \e[37mactual\e[0m\n\n#{r}line1\n#{r}line2"}
-        let(:r) { ::Term::ANSIColor.reset }
+        let(:output_message_with_resets) { "Actual: \e[37mactual\e[0m\n\n#{Rainbow('line1').white}\n#{Rainbow('line2').white}"}
         let(:diff) { double("diff") }
         let(:actual) { "actual" }
         let(:color_enabled) { true }
-        let(:ansi_reset_at_start_of_line) { /^#{Regexp.escape ::Term::ANSIColor.reset}/ }
         let(:message_line_count) { message.split("\n").size }
 
         before do

--- a/spec/support/cli.rb
+++ b/spec/support/cli.rb
@@ -9,14 +9,12 @@ module Pact
       end
 
       def ensure_patterns_present command, options, output
-        require 'term/ansicolor'
         options[:with].each do | pattern |
           raise ("Could not find #{pattern.inspect} in output of #{command}" + "\n\n#{output}") unless output =~ pattern
         end
       end
 
       def ensure_patterns_not_present command, options, output
-        require 'term/ansicolor'
         options[:without].each do | pattern |
           raise ("Expected not to find #{pattern.inspect} in output of #{command}" + "\n\n#{output}") if output =~ pattern
         end

--- a/tasks/pact-test.rake
+++ b/tasks/pact-test.rake
@@ -124,10 +124,10 @@ namespace :pact do
 	end
 
 	def ensure_patterns_present command, options, stdout, stderr
-		require 'term/ansicolor'
+		require 'rainbow'
 		output = stdout.read + stderr.read
 		options[:with].each do | pattern |
-			raise (::Term::ANSIColor.red("Could not find #{pattern.inspect} in output of #{command}") + "\n\n#{output}") unless output =~ pattern
+			raise (Rainbow("Could not find #{pattern.inspect} in output of #{command}").red + "\n\n#{output}") unless output =~ pattern
 		end
 	end
 end


### PR DESCRIPTION
The `term-ansicolor` gem injects a global `Term` module that has a high probability of naming collision for other common class names. This PR replaces that gem with the `rainbow` gem to avoid this issue.