### PR TITLE
refactor: remove deps from gemspec to avoid pulling in published gems

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -32,9 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency "rainbow", "~> 3.0"
 
-  gem.add_runtime_dependency 'pact-support', '~> 1.17', '>= 1.16.9'
-  gem.add_runtime_dependency 'pact-mock_service', '~> 3.9', '>= 3.3.1'
-
   gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'webmock', '~> 3.0'
   gem.add_development_dependency 'fakefs', '0.5' # 0.6.0 blows up


### PR DESCRIPTION
Remove runtime dependencies as well to ensure the package pulls from the gemfile.